### PR TITLE
prefix asset urls with baseurl

### DIFF
--- a/asset_path_tag.rb
+++ b/asset_path_tag.rb
@@ -47,7 +47,7 @@ module Jekyll
       path = File.dirname(path) if path =~ /\.\w+$/
 
       #fix double slashes
-      "/assets/#{path}/#{@filename}".gsub(/\/{2,}/, '/')
+      "#{context.registers[:site].config['baseurl']}/assets/#{path}/#{@filename}".gsub(/\/{2,}/, '/')
     end
   end
 end


### PR DESCRIPTION
I was trying to use jekyll-asset-path-plugin with my Jekyll blog hosted under a subdir (e.g. http://example.com/blog/) and found that the asset URLs lacked the "baseurl" specified in the config.yml file. It might be a consequence of my particular web server configuration, but it seems that adding on the baseurl resolves the issue.
