### PR TITLE
Updated for Jekyll 3

### DIFF
--- a/asset_path_tag.rb
+++ b/asset_path_tag.rb
@@ -52,10 +52,20 @@ module Jekyll
 
       #if a post
       if page["id"]
-        #loop through posts to find match and get slug
-        context.registers[:site].posts.docs.each do |post|
-          if post.id == page["id"]
-            path = "posts/#{post.data['slug']}"
+        #check for Jekyll version
+        if Jekyll::VERSION < '3.0.0'
+          #loop through posts to find match and get slug
+          context.registers[:site].posts.each do |post|
+            if post.id == page["id"]
+              path = "posts/#{post.slug}"
+            end
+          end
+        else
+        #loop through posts to find match and get slug, method calls for Jekyll 3
+          context.registers[:site].posts.docs.each do |post|
+            if post.id == page["id"]
+              path = "posts/#{post.data['slug']}"
+            end
           end
         end
       else

--- a/asset_path_tag.rb
+++ b/asset_path_tag.rb
@@ -53,9 +53,9 @@ module Jekyll
       #if a post
       if page["id"]
         #loop through posts to find match and get slug
-        context.registers[:site].posts.each do |post|
+        context.registers[:site].posts.docs.each do |post|
           if post.id == page["id"]
-            path = "posts/#{post.slug}"
+            path = "posts/#{post.data['slug']}"
           end
         end
       else


### PR DESCRIPTION
Posts are documents now, call site.posts.docs instead of site.posts.

Post properties are now stored in post.data, call post.data['slug']
instead of post.slug.