### PR TITLE
Fix RuboCop warnings

### DIFF
--- a/asset_path_tag.rb
+++ b/asset_path_tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Title: Asset path tag for Jekyll
 # Authors:
 #     Sam Rayner http://samrayner.com
@@ -47,72 +49,67 @@
 # /assets/posts/another-post-title/cover.jpg
 
 module Jekyll
-
   def self.get_post_path(page_id, posts)
-    #check for Jekyll version
+    # check for Jekyll version
     if Jekyll::VERSION < '3.0.0'
-      #loop through posts to find match and get slug
+      # loop through posts to find match and get slug
       posts.each do |post|
-        if post.id == page_id
-          return "posts/#{post.slug}"
-        end
+        return "posts/#{post.slug}" if post.id == page_id
       end
     else
-      #loop through posts to find match and get slug, method calls for Jekyll 3
+      # loop through posts to find match and get slug, method calls for Jekyll 3
       posts.docs.each do |post|
-        if post.id == page_id
-          return "posts/#{post.data['slug']}"
-        end
+        return "posts/#{post.data['slug']}" if post.id == page_id
       end
     end
 
-    return ""
+    ''
   end
 
   class AssetPathTag < Liquid::Tag
     @markup = nil
 
     def initialize(tag_name, markup, tokens)
-      #strip leading and trailing spaces
+      # strip leading and trailing spaces
       @markup = markup.strip
       super
     end
 
     def render(context)
       if @markup.empty?
-        return "Error processing input, expected syntax: {% asset_path filename post_id %}"
+        return 'Error processing input, expected syntax: {% asset_path filename post_id %}'
       end
 
-      #render the markup
+      # render the markup
       parameters = Liquid::Template.parse(@markup).render context
       parameters.strip!
 
-      if ['"', "'"].include? parameters[0] 
+      if ['"', "'"].include? parameters[0]
         # Quoted filename, possibly followed by post id
         last_quote_index = parameters.rindex(parameters[0])
-        filename = parameters[1 ... last_quote_index]
-        post_id = parameters[(last_quote_index + 1) .. -1].strip
+        filename = parameters[1...last_quote_index]
+        post_id = parameters[(last_quote_index + 1)..-1].strip
       else
         # Unquoted filename, possibly followed by post id
         filename, post_id = parameters.split(/\s+/)
       end
 
-      page = context.environments.first["page"]
+      page = context.environments.first['page']
 
-      post_id = page["id"] if post_id == nil or post_id.empty?
+      post_id = page['id'] if post_id.nil? || post_id.empty?
       if post_id
-        #if a post
+        # if a post
         posts = context.registers[:site].posts
         path = Jekyll.get_post_path(post_id, posts)
       else
-        path = page["url"]
+        path = page['url']
       end
 
-      #strip filename
+      # strip filename
       path = File.dirname(path) if path =~ /\.\w+$/
 
-      #fix double slashes
-      "#{context.registers[:site].config['baseurl']}/assets/#{path}/#{filename}".gsub(/\/{2,}/, '/')
+      # fix double slashes
+      "#{context.registers[:site].config['baseurl']}/assets/#{path}/#{filename}".gsub(%r{/{2,}}, '/')
     end
   end
 end

--- a/asset_path_tag.rb
+++ b/asset_path_tag.rb
@@ -81,7 +81,8 @@ module Jekyll
 
     def render(context)
       if @markup.empty?
-        return 'Error processing input, expected syntax: {% asset_path filename post_id %}'
+        return 'Error processing input, expected syntax: ' \
+               '{% asset_path filename post_id %}'
       end
 
       # render the markup
@@ -101,7 +102,8 @@ module Jekyll
       path = File.dirname(path) if path =~ /\.\w+$/
 
       # fix double slashes
-      "#{context.registers[:site].config['baseurl']}/assets/#{path}/#{filename}".gsub(%r{/{2,}}, '/')
+      "#{context.registers[:site].config['baseurl']}/assets/#{path}/#{filename}"
+        .gsub(%r{/{2,}}, '/')
     end
 
     private

--- a/asset_path_tag.rb
+++ b/asset_path_tag.rb
@@ -52,6 +52,7 @@
 
 # rubocop: enable Metrics/LineLength
 
+# Jekyll plugin.
 module Jekyll
   def self.get_post_path(page_id, posts)
     # check for Jekyll version
@@ -70,6 +71,7 @@ module Jekyll
     ''
   end
 
+  # Returns the path to the specified asset.
   class AssetPathTag < Liquid::Tag
     @markup = nil
 

--- a/asset_path_tag.rb
+++ b/asset_path_tag.rb
@@ -87,16 +87,7 @@ module Jekyll
 
       # render the markup
       filename, post_id = parse_parameters context
-      page = context.environments.first['page']
-
-      post_id = page['id'] if post_id.nil? || post_id.empty?
-      if post_id
-        # if a post
-        posts = context.registers[:site].posts
-        path = Jekyll.get_post_path(post_id, posts)
-      else
-        path = page['url']
-      end
+      path = post_path context, post_id
 
       # strip filename
       path = File.dirname(path) if path =~ /\.\w+$/
@@ -121,6 +112,19 @@ module Jekyll
       end
       # Unquoted filename, possibly followed by post id
       parameters.split(/\s+/)
+    end
+
+    def post_path(context, post_id)
+      page = context.environments.first['page']
+
+      post_id = page['id'] if post_id.nil? || post_id.empty?
+      if post_id
+        # if a post
+        posts = context.registers[:site].posts
+        Jekyll.get_post_path(post_id, posts)
+      else
+        page['url']
+      end
     end
   end
 end

--- a/asset_path_tag.rb
+++ b/asset_path_tag.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop: disable Metrics/LineLength
+
 # Title: Asset path tag for Jekyll
 # Authors:
 #     Sam Rayner http://samrayner.com
@@ -47,6 +49,8 @@
 # Output:
 # /assets/posts/post-title/cover.jpg
 # /assets/posts/another-post-title/cover.jpg
+
+# rubocop: enable Metrics/LineLength
 
 module Jekyll
   def self.get_post_path(page_id, posts)

--- a/asset_path_tag.rb
+++ b/asset_path_tag.rb
@@ -85,19 +85,7 @@ module Jekyll
       end
 
       # render the markup
-      parameters = Liquid::Template.parse(@markup).render context
-      parameters.strip!
-
-      if ['"', "'"].include? parameters[0]
-        # Quoted filename, possibly followed by post id
-        last_quote_index = parameters.rindex(parameters[0])
-        filename = parameters[1...last_quote_index]
-        post_id = parameters[(last_quote_index + 1)..-1].strip
-      else
-        # Unquoted filename, possibly followed by post id
-        filename, post_id = parameters.split(/\s+/)
-      end
-
+      filename, post_id = parse_parameters context
       page = context.environments.first['page']
 
       post_id = page['id'] if post_id.nil? || post_id.empty?
@@ -114,6 +102,23 @@ module Jekyll
 
       # fix double slashes
       "#{context.registers[:site].config['baseurl']}/assets/#{path}/#{filename}".gsub(%r{/{2,}}, '/')
+    end
+
+    private
+
+    def parse_parameters(context)
+      parameters = Liquid::Template.parse(@markup).render context
+      parameters.strip!
+
+      if ['"', "'"].include? parameters[0]
+        # Quoted filename, possibly followed by post id
+        last_quote_index = parameters.rindex(parameters[0])
+        filename = parameters[1...last_quote_index]
+        post_id = parameters[(last_quote_index + 1)..-1].strip
+        return filename, post_id
+      end
+      # Unquoted filename, possibly followed by post id
+      parameters.split(/\s+/)
     end
   end
 end


### PR DESCRIPTION
The RuboCop linter complains about a 36 issues. This PR fixes all of the default warnings except for too-long lines in the comments in the examples which are ignored.